### PR TITLE
TASK-190:revise API to read purchase and sales log

### DIFF
--- a/backend/controller/purchaseController.js
+++ b/backend/controller/purchaseController.js
@@ -17,8 +17,16 @@ export const createPurchase = async (req, res) => {
 
 export const getAllPurchase = async (req, res) => {
   try {
-    const purchase = await Purchase.find().populate('farmer_id');;
-    console.log("Purchase retrieved");
+    const user = await UserModel.findById(req.params.userid);
+    const purchase = await Purchase.aggregate([
+      {
+        $match: {
+          _id: {
+            $in: user.purchases_array,
+          },
+        },
+      },
+    ]);
     res.status(200).json(purchase);
   } catch (err) {
     res.status(500).json({
@@ -53,10 +61,10 @@ export const updatePurchase = async (req, res) => {
       return res.status(404).json({
         error: "Purchase not found",
       });
-    } 
-      return res.status(201).json({
-        status: "success in updating",
-      });    
+    }
+    return res.status(201).json({
+      status: "success in updating",
+    });
   } catch (err) {
     console.log(err);
     res.status(400).json({
@@ -123,7 +131,7 @@ export const getTodaysTotalPurchasePriceForUser = async (req, res) => {
   const user = await UserModel.findById(req.params.userid);
   const startOfDay = new Date();
   startOfDay.setUTCHours(0, 0, 0, 0); // Set to start of today in UTC
-  
+
   const endOfDay = new Date();
   endOfDay.setUTCHours(23, 59, 59, 999); // Set to end of today in UTC
 
@@ -134,16 +142,16 @@ export const getTodaysTotalPurchasePriceForUser = async (req, res) => {
           _id: { $in: user.purchases_array },
           purchase_date: {
             $gte: startOfDay,
-            $lte: endOfDay
-          }
-        }
+            $lte: endOfDay,
+          },
+        },
       },
       {
         $group: {
           _id: null,
-          totalSum: { $sum: "$total_purchase_price" }
-        }
-      }
+          totalSum: { $sum: "$total_purchase_price" },
+        },
+      },
     ]);
 
     if (result.length === 0 || !result[0].totalSum) {
@@ -154,7 +162,7 @@ export const getTodaysTotalPurchasePriceForUser = async (req, res) => {
     }
     res.status(200).json({
       status: "success",
-      totalSum: result[0].totalSum
+      totalSum: result[0].totalSum,
     });
   } catch (err) {
     res.status(500).json({


### PR DESCRIPTION
Revised the existing APIs for sales and purchase log. 
Before : the API took all the logs regardless of userID 
After : the API can retrieve the data by userID
You can test by below endpoints;

sales : 
`http://localhost:5555/tmpFinRoute/66622c07858df5960bf57a06/sale`

purchase : 
`http://localhost:5555/tmpFinRoute/66640d8158d2c8dc4cedaf1e/purchase`