### PR TITLE
Add API to get nearest sales log date with pending status

### DIFF
--- a/backend/controller/saleController.js
+++ b/backend/controller/saleController.js
@@ -222,3 +222,39 @@ export const getWeeklyCompletedSalesSumByUserSalesArray = async (req, res) => {
     });
   }
 };
+
+export const getNearestPendingSaleDate = async (req, res) => {
+  try {
+    const userId = req.params.userid;
+    const currentDate = new Date();
+
+    const nearestPendingSale = await Sale.findOne({ 
+      user_id: userId, 
+      status: "pending",
+      copra_ship_date: { $gt: currentDate }
+    })
+    .sort({ copra_ship_date: 1 }); 
+
+    if (!nearestPendingSale) {
+      return res.status(404).json({
+        status: "fail",
+        message: "No pending sales found for this user",
+      });
+    }
+    const formattedDate = nearestPendingSale.copra_ship_date.toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: '2-digit'
+    });
+
+    res.status(200).json({
+      status: "success",
+      date: formattedDate,
+    });
+  } catch (err) {
+    res.status(500).json({
+      status: "fail",
+      message: err.message,
+    });
+  }
+};

--- a/backend/route/saleRoute.js
+++ b/backend/route/saleRoute.js
@@ -5,6 +5,7 @@ const router = express.Router({ mergeParams: true });
 router.get("/", saleController.getAllSales);
 router.get("/weekly-sales-sum", saleController.getWeeklyCompletedSalesSumByUserSalesArray);
 router.get("/monthly-aggregate", saleController.aggregateMonthlySales);
+router.get("/latest-pending/:userid", saleController.getNearestPendingSaleDate); 
 router.get("/:id", saleController.getSaleById);
 router.post("/", saleController.createSale);
 router.patch("/:id", saleController.updateSale);


### PR DESCRIPTION
@c-est-sa request this is the API to get the nearest date of  sales log with pending status to display in dashboard