### PR TITLE
fix: disabled, required behavior on EditSalesModal

### DIFF
--- a/frontend/src/component/field-filter/Field.jsx
+++ b/frontend/src/component/field-filter/Field.jsx
@@ -6,7 +6,7 @@ import {
   TextField,
 } from "@mui/material";
 import { TextareaAutosize } from "@mui/base/TextareaAutosize";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import VisibilityOn from "../../assets/icons/Eye-On.svg";
 import VisibilityOff from "../../assets/icons/Eye-Off.svg";
 import Info from "../../assets/icons/Information.svg";
@@ -39,6 +39,13 @@ const Field = ({
   };
 
   let inputElement = null;
+
+  // (From Aki to Prathibha: I added this for EditSaleModal.jsx. I believe this is not gonna cause any issues in other areas. It's difficult to tell what I'm trying to do here. So pls let me explain tmr)
+  useEffect(() => {
+    if (disabled !== isDisabled) {
+      setIsDisabled(!isDisabled);
+    }
+  }, [disabled, isDisabled]);
 
   switch (type) {
     case "number":

--- a/frontend/src/page/sale/EditSaleModal.jsx
+++ b/frontend/src/page/sale/EditSaleModal.jsx
@@ -259,6 +259,7 @@ const EditSaleModal = ({ showEditForm, setshowEditForm, selectedSale, setSelecte
           type="number"
           value={formData.amount_of_copra_sold}
           onChange={handleChange}
+          required
         />
         <Field
           label="Sales Unit Price"
@@ -280,6 +281,7 @@ const EditSaleModal = ({ showEditForm, setshowEditForm, selectedSale, setSelecte
             { value: "completed", label: "Completed" },
             // { value: "cancelled", label: "Cancelled" },
           ]}
+          required
         />
         <Field
           label="Copra Ship Date"
@@ -287,6 +289,7 @@ const EditSaleModal = ({ showEditForm, setshowEditForm, selectedSale, setSelecte
           type="date"
           value={formData.copra_ship_date}
           onChange={handleChange}
+          required
         />
         <Field
           label="Cheque Receive Date"
@@ -294,6 +297,10 @@ const EditSaleModal = ({ showEditForm, setshowEditForm, selectedSale, setSelecte
           type="date"
           value={formData.cheque_receive_date}
           onChange={handleChange}
+          disabled={formData.status !== "completed"}
+          required={formData.status === "completed"}
+          info
+          infoText="You can choose the date only when you change status to completed."
         />
         <Field
           label="Total Sales Price"
@@ -301,6 +308,10 @@ const EditSaleModal = ({ showEditForm, setshowEditForm, selectedSale, setSelecte
           type="number"
           value={formData.total_sales_price}
           onChange={handleChange}
+          disabled={formData.status !== "completed"}
+          required={formData.status === "completed"}
+          info
+          infoText="You can type in total amount of sales only when you change status to completed."
         />
         <CtaBtn
           size="S"
@@ -310,10 +321,10 @@ const EditSaleModal = ({ showEditForm, setshowEditForm, selectedSale, setSelecte
         />
         <CtaBtn 
           size="S" 
-          level={new Date(formData.copra_ship_date) > new Date() ? "D" : "P"} 
+          level={new Date(formData.copra_ship_date) > new Date() && formData.status !== "pending" ? "D" : "P"}
           type="submit" 
           innerTxt="Save" 
-          disabled = {new Date(formData.copra_ship_date) > new Date()}
+          disabled = {new Date(formData.copra_ship_date) > new Date() && formData.status !== "pending"}
         />
       </form>
     </div>


### PR DESCRIPTION
So changes I made are like below.

For fields about required and disabled,
- When pending, input fields for money received date and money amount are disabled
- when ongoing, those fields are still disabled
- when completed, finally they get un-disabled so that they can enter those numbers. And then those fields are required

For save btn, 
- users can't save the edit if the shipment date is in the future
- EXCEPTION is when status is ongoing as it doesn't affect copra amount data in inv doc because copra hasn't get shipped yet.

