### PR TITLE
CBT-15: fix: update sales table after creating new sales

### DIFF
--- a/frontend/src/page/inventory/Inventory.jsx
+++ b/frontend/src/page/inventory/Inventory.jsx
@@ -78,7 +78,7 @@ const Inventory = ({ URL }) => {
         message={confirmationMessage}
       />
       <LineChartRevised userId={userId} URL={URL} />
-      <SalesTable userId={userId} URL={URL} />
+      <SalesTable userId={userId} URL={URL} showConfirmation={showConfirmation}/>
     </div>
   );
 };

--- a/frontend/src/page/inventory/SalesTable.jsx
+++ b/frontend/src/page/inventory/SalesTable.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import axios from "axios";
 
-const SalesTable = ({ userId, URL }) => {
+const SalesTable = ({ userId, URL, showConfirmation }) => {
   const [sales, setSales] = useState([]);
 
   useEffect(
@@ -11,7 +11,7 @@ const SalesTable = ({ userId, URL }) => {
       });
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
+    [showConfirmation]
   );
 
   return (


### PR DESCRIPTION
Now when a user create a new shipment/sales, it automatically update the small sales table on the inventory page.