### PR TITLE
CBT-35: fix: y axis to "**k" and from 0k to just 0

### DIFF
--- a/frontend/src/page/finance/LineChart.jsx
+++ b/frontend/src/page/finance/LineChart.jsx
@@ -264,7 +264,8 @@ const LineChart = (t) => {
             },
             ticks: {
               callback(value) {
-                return `${value / 1000}k`; // Use template literals
+                const valueToShow = value === 0 ? "0" : `${value / 1000}k`
+                return valueToShow;
               },
             },
           },

--- a/frontend/src/page/finance/MonthlyActivity.jsx
+++ b/frontend/src/page/finance/MonthlyActivity.jsx
@@ -181,7 +181,8 @@ const MonthlyActivity = ({ URL }) => {
             beginAtZero: true,
             ticks: {
               callback(value) {
-                return `${value / 1000}k`; // Use template literals
+                const valueToShow = value === 0 ? "0" : `${value / 1000}k`
+                return valueToShow;
               },
               font: {
                 size: 14, // Change this to the desired font size

--- a/frontend/src/page/inventory/LineChartRevised.jsx
+++ b/frontend/src/page/inventory/LineChartRevised.jsx
@@ -169,6 +169,12 @@ const LineChartRevised = ({ userId, URL, dashboard = false }) => {
               grid: {
                 display: false,
               },
+              ticks: {
+                callback(value) {
+                  const valueToShow = value === 0 ? "0" : `${value / 1000}k`
+                  return valueToShow;
+                },
+              },
             },
           },
           plugins: {


### PR DESCRIPTION
Now y axis on the inventory page show numbers not in a raw number but in k style.
I also added a small modification to make sure that 0 is shown as 0 instead of 0k